### PR TITLE
Snapcraft.yaml to create basic snap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+parts/
+prime/
+stage/
+*.snap
+

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,18 @@
+name: upload-assets
+version: '0.1.0'
+summary: A command-line tool for managing the assets server
+description: |
+  This is intended to be a simple command-line tool for uploading assets 
+  to an https://assets.ubuntu.com-like assets server.
+
+grade: stable
+confinement: strict
+
+parts:
+  repo:
+    plugin: python3
+    source: .
+
+apps:
+  upload-assets:
+    command: upload-assets


### PR DESCRIPTION
## Done
Created a snapcraft.yaml to install asset-uploader as an app.

## QA
- Run `snapcraft`
- Run `snap install upload-assets_0.1.0_amd64.snap`
- Run:
```bash 
$ upload-assets  \
    --api-url https://assets.EXAMPLE.com/v1/  \
    --api-token XXXXXXXX  \
    ~/EXAMPLE_DIRECTORY ./EXAMPLE_IMAGE.png
```
- Check the image as uploaded
- _Contact me for API token_