### PR TITLE
Ignore generated directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,7 @@ parts/
 prime/
 stage/
 *.snap
-
+*.egg-info/
+dist/
+env/
+env3/


### PR DESCRIPTION
Including .egg-info and dist (generated by setup.py) and env
directories (often used with python venv)