### PR TITLE
Change API_SECRET_TOKEN to UPLOAD_ASSETS_API_TOKEN

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,3 +32,15 @@ You should now have access to the ``upload-assets``\ command:
         {"url": "https://assets.ubuntu.com/v1/2071d161-IMAGE1.png", "filepath": "/home/robin/EXAMPLE_DIRECTORY/IMAGE1.png"},
         {"url": "https://assets.ubuntu.com/v1/2071d161-IMAGE2.png", "filepath": "/home/robin/EXAMPLE_DIRECTORY/IMAGE2.png"}
     ]
+
+Configuration
+---
+
+To avoid specifying them every time, you can store both the URL and the token
+for the assets API in environment variables:
+
+.. code:: bash
+
+    $ export API_BASE_URL=https://<api-domain>/v1/
+    $ export UPLOAD_ASSETS_API_TOKEN=<api-token>
+    $ upload-assets EXAMPLE_IMAGE.png

--- a/upload-assets
+++ b/upload-assets
@@ -8,7 +8,7 @@ import os
 from canonicalwebteam.upload_assets.uploader import gather_files, upload_files
 
 api_base_url = os.environ.get('API_BASE_URL', 'https://assets.ubuntu.com/v1/')
-api_secret_token = os.environ.get('API_SECRET_TOKEN')
+api_secret_token = os.environ.get('UPLOAD_ASSETS_API_TOKEN')
 
 parser = argparse.ArgumentParser(
     description='Upload assets from this directory'
@@ -30,7 +30,8 @@ parser.add_argument(
 )
 parser.add_argument(
     '-t', '--tags',
-    help='Tags for uploaded assets', default='auto-upload'
+    help='Tags for uploaded assets',
+    default='auto-upload'
 )
 parser.add_argument(
     'upload_paths',


### PR DESCRIPTION
It's better to have a more specific environment variable. Also, document
the environment variables in the README better.

QA
--

``` bash
$ python3 -m venv env3
$ source env3/bin/activate
$ pip install -e .

$ API_SECRET_TOKEN=xxxx upload-assets some-file.png
usage: upload-assets [-h] [-u API_URL] -s API_TOKEN [-p URL_PATH] [-t TAGS]
                     upload_paths [upload_paths ...]
upload-assets: error: the following arguments are required: -s/--api-token, upload_paths

$ UPLOAD_ASSETS_API_TOKEN=xxxx upload-assets some-file.png
[{"url": "https://assets.ubuntu.com/v1/7ad484f6-some-file.png", "local_filepath": "... some-file.png"}]
```