### PR TITLE
Bump to version 0.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ assert sys.version_info >= (3, 5), (
 
 setup(
     name='canonicalwebteam.upload-assets',
-    version='0.1.1',
+    version='0.2.0',
     author='Canonical webteam',
     author_email='robin+pypi@canonical.com',
     url='https://github.com/canonical-webteam/upload-assets',

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: upload-assets
-version: '0.1.1'
+version: '0.2.0'
 summary: A command-line tool for managing the assets server
 description: |
   This is intended to be a simple command-line tool for uploading assets 


### PR DESCRIPTION
This is a minor version change because we've renamed the local
environment variables, and so this change could be breaking.