### PR TITLE
Catch json decode errors

### DIFF
--- a/canonicalwebteam/upload_assets/uploader.py
+++ b/canonicalwebteam/upload_assets/uploader.py
@@ -7,6 +7,7 @@ import base64
 import glob
 import json
 import os
+import re
 import sys
 
 # Third party packages
@@ -50,8 +51,14 @@ def _upload_file(
         requests.exceptions.JSONDecodeError,
     ) as request_error:
         if request_error.response.status_code == 409:
+            # Try to get the remote file path, or return the filename
+            match = re.search(r'.*<p>(.*)</p>', response.text)
+            if match:
+                file_url = f"{response.url}/{match.group(1)}"
+            else:
+                file_url = filename
             print(
-                f"Error: URL path already exists: {url_path}",
+                f"Error: This file has already been uploaded: {file_url}",
                 file=sys.stderr,
             )
             sys.exit(1)

--- a/canonicalwebteam/upload_assets/uploader.py
+++ b/canonicalwebteam/upload_assets/uploader.py
@@ -49,11 +49,9 @@ def _upload_file(
         requests.exceptions.HTTPError,
         requests.exceptions.JSONDecodeError,
     ) as request_error:
-        if request_error.response.status_code == 409 and error_on_exists:
+        if request_error.response.status_code == 409:
             print(
-                "Error: URL path already exists: {url}".format(
-                    url=os.path.join(api_url, url_path)
-                ),
+                f"Error: URL path already exists: {url_path}",
                 file=sys.stderr,
             )
             sys.exit(1)

--- a/upload-assets
+++ b/upload-assets
@@ -61,7 +61,7 @@ if cli_arguments['version']:
         ).version
     )
     sys.exit()
-elif not bool(api_secret_token):
+elif not cli_arguments['api_token'] and not bool(api_secret_token):
     print(
         "Error: API secret token required (--api-token|-s)"
     )


### PR DESCRIPTION
## Done
- Added a check to more elegantly catch and report JSONDecode errors

## QA 
- Install the package using
```bash
pip install .
```
- Get a token for the staging asset manager [here](https://pastebin.canonical.com/p/FB5tpxqGWh/)
- Try uploading a file that already exists, and check the error response. It should print the path and a message rather than a stack trace.
```bash
upload-assets --api-domain manager.assets.staging.ubuntu.com --api-token <api-token>  somefile.png
upload-assets --api-domain manager.assets.staging.ubuntu.com --api-token <api-token>  somefile.png # should raise an error
```

## Fixes
[WD-1575](https://warthogs.atlassian.net/browse/WD-1575?atlOrigin=eyJpIjoiMjc4YTdlMTEyMjg4NDE3NDk0MDUwNTYyZGQ3NDUwMGIiLCJwIjoiaiJ9)
#44 


[WD-1575]: https://warthogs.atlassian.net/browse/WD-1575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ