### PR TITLE
Fix url path

### DIFF
--- a/canonicalwebteam/upload_assets/uploader.py
+++ b/canonicalwebteam/upload_assets/uploader.py
@@ -57,6 +57,7 @@ def _upload_file(
             "asset-type": asset_type,
             "author": author,
             "friendly-name": filename,
+            "url-path": url_path,
         }
 
         # Prepare the file for upload

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ assert sys.version_info >= (3, 5), "upload-assets requires Python 3.5 or newer"
 
 setup(
     name="canonicalwebteam.upload-assets",
-    version="0.4.0",
+    version="0.4.1",
     author="Canonical webteam",
     author_email="robin+pypi@canonical.com",
     url="https://github.com/canonical-web-and-design/upload-assets",

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,9 +1,9 @@
 name: upload-assets
-base: core18
-version: '0.3.0'
+base: core22
+version: "0.4.0"
 summary: A command-line tool for managing the assets server
 description: |
-  This is intended to be a simple command-line tool for uploading assets 
+  This is intended to be a simple command-line tool for uploading assets
   to an https://assets.ubuntu.com-like assets server.
 
 grade: stable
@@ -13,10 +13,12 @@ parts:
   repo:
     plugin: python
     source: .
+    python-requirements:
+      - requirements.txt
 
 apps:
   upload-assets:
-    command: upload-assets
+    command: /bin/upload-assets
     plugs:
       - home
       - network-bind

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: upload-assets
 base: core22
-version: "0.4.0"
+version: "0.4.1"
 summary: A command-line tool for managing the assets server
 description: |
   This is intended to be a simple command-line tool for uploading assets

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,7 +18,7 @@ parts:
 
 apps:
   upload-assets:
-    command: /bin/upload-assets
+    command: bin/upload-assets
     plugs:
       - home
       - network-bind


### PR DESCRIPTION
## Done
- fixed bug where url-path wasn't being set as the asset name

## QA
- Clone and install this branch using `pip install .`
- upload an asset to staging using [these credentials](https://pastebin.canonical.com/p/5MgCjZ2DBx/), and
```bash
upload-assets --url-path assetfile.png <asset-file>
```